### PR TITLE
exposed response functions

### DIFF
--- a/src/apple.rs
+++ b/src/apple.rs
@@ -7,10 +7,21 @@ use hyper_tls::HttpsConnector;
 
 //https://developer.apple.com/documentation/appstorereceipts/status
 const APPLE_STATUS_CODE_TEST: i32 = 21007;
+const APPLE_PROD_VERIFY_RECEIPT: &str = "https://buy.itunes.apple.com";
+const APPLE_TEST_VERIFY_RECEIPT: &str = "https://sandbox.itunes.apple.com";
 
-pub struct AppleUrls {
-    pub production: String,
-    pub sandbox: String,
+pub struct AppleUrls<'a> {
+    pub production: &'a str,
+    pub sandbox: &'a str,
+}
+
+impl Default for AppleUrls<'_> {
+    fn default() -> Self {
+        AppleUrls {
+            production: APPLE_PROD_VERIFY_RECEIPT,
+            sandbox: APPLE_TEST_VERIFY_RECEIPT,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -56,7 +67,15 @@ pub struct AppleResponse {
 /// Retrieves the responseBody data from Apple
 pub async fn apple_response(
     receipt: &UnityPurchaseReceipt,
-    apple_urls: &AppleUrls,
+    password: Option<&String>,
+) -> Result<AppleResponse> {
+    apple_response_internal(receipt, &AppleUrls::default(), password).await
+}
+
+/// Internal function call with apple_urls parameter for tests
+pub async fn apple_response_internal(
+    receipt: &UnityPurchaseReceipt,
+    apple_urls: &AppleUrls<'_>,
     password: Option<&String>,
 ) -> Result<AppleResponse> {
     let https = HttpsConnector::new();

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -69,11 +69,11 @@ pub async fn apple_response(
     receipt: &UnityPurchaseReceipt,
     password: Option<&String>,
 ) -> Result<AppleResponse> {
-    apple_response_internal(receipt, &AppleUrls::default(), password).await
+    apple_response_with_urls(receipt, &AppleUrls::default(), password).await
 }
 
-/// Internal function call with apple_urls parameter for tests
-pub async fn apple_response_internal(
+/// Response call with apple_urls parameter for tests
+pub async fn apple_response_with_urls(
     receipt: &UnityPurchaseReceipt,
     apple_urls: &AppleUrls<'_>,
     password: Option<&String>,

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -82,8 +82,8 @@ pub async fn apple_response_internal(
     let client = Client::builder().build::<_, hyper::Body>(https);
 
     let password = password
-    .cloned()
-    .ok_or_else(|| IoError(std::io::Error::new(std::io::ErrorKind::NotFound, "no apple secret has been set")))?;
+        .cloned()
+        .ok_or_else(|| IoError(std::io::Error::new(std::io::ErrorKind::NotFound, "no apple secret has been set")))?;
     let request_body = serde_json::to_string(&AppleRequest {
         receipt_data: receipt.payload.clone(),
         password,

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -56,7 +56,6 @@ pub struct AppleResponse {
     pub is_retryable: Option<bool>,
     pub environment: Option<String>,
     /// The latest Base64 encoded app receipt. Only returned for receipts that contain auto-renewable subscriptions. 
-    #[serde(rename = "latest-receipt")]
     pub latest_receipt: Option<String>,
     /// An array that contains all in-app purchase transactions. This excludes transactions for consumable products
     /// that have been marked as finished by your app. Only returned for receipts that contain auto-renewable subscriptions.

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -3,6 +3,7 @@ use async_recursion::async_recursion;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use hyper::{body, Body, Client, Request};
+use hyper_tls::HttpsConnector;
 
 //https://developer.apple.com/documentation/appstorereceipts/status
 const APPLE_STATUS_CODE_TEST: i32 = 21007;
@@ -43,26 +44,38 @@ pub struct AppleResponse {
     #[serde(rename = "is-retryable")]
     pub is_retryable: Option<bool>,
     pub environment: Option<String>,
+    /// The latest Base64 encoded app receipt. Only returned for receipts that contain auto-renewable subscriptions. 
+    #[serde(rename = "latest-receipt")]
+    pub latest_receipt: Option<String>,
     /// An array that contains all in-app purchase transactions. This excludes transactions for consumable products
     /// that have been marked as finished by your app. Only returned for receipts that contain auto-renewable subscriptions.
+    #[serde(rename = "latest-receipt-info")]
     pub latest_receipt_info: Option<Vec<AppleLatestReceipt>>,
 }
 
-pub async fn validate_apple(
+/// Retrieves the responseBody data from Apple
+pub async fn apple_response(
     receipt: &UnityPurchaseReceipt,
-    client: &Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>,
     apple_urls: &AppleUrls,
     password: Option<&String>,
-) -> Result<PurchaseResponse> {
+) -> Result<AppleResponse> {
+    let https = HttpsConnector::new();
+    let client = Client::builder().build::<_, hyper::Body>(https);
+
     let password = password
-        .cloned()
-        .ok_or_else(|| IoError(std::io::Error::new(std::io::ErrorKind::NotFound, "no apple secret has been set")))?;
+    .cloned()
+    .ok_or_else(|| IoError(std::io::Error::new(std::io::ErrorKind::NotFound, "no apple secret has been set")))?;
     let request_body = serde_json::to_string(&AppleRequest {
         receipt_data: receipt.payload.clone(),
         password,
     })?;
-    let response = get_apple_response(client, &request_body, apple_urls, true).await?;
+    get_apple_response(&client, &request_body, apple_urls, true).await
+}
 
+pub async fn validate_apple_subscription(
+    response: AppleResponse
+) -> Result<PurchaseResponse> {
+    
     let now = Utc::now().timestamp_millis();
 
     let valid = response

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use hyper;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/google.rs
+++ b/src/google.rs
@@ -1,4 +1,4 @@
-use super::{error, error::Result, PurchaseResponse};
+use super::{error, error::Result, PurchaseResponse, UnityPurchaseReceipt};
 use chrono::Utc;
 use serde::{de::Error, Deserialize, Serialize};
 use hyper::{body, Body, Client, Request};
@@ -77,6 +77,16 @@ pub struct GooglePlayDataJson {
 
 /// Retrieves the response body from google
 pub async fn google_response(
+    receipt: &UnityPurchaseReceipt, 
+    service_account_key: Option<&ServiceAccountKey>,
+) -> Result<GoogleResponse> {
+    let data = GooglePlayData::from(&receipt.payload)?;
+    let uri = data.get_uri()?;
+    google_response_with_uri(service_account_key, uri).await
+}
+
+/// Retrieves the google response with a specific uri, useful for running tests.
+pub async fn google_response_with_uri(
     service_account_key: Option<&ServiceAccountKey>,
     uri: String,
 ) -> Result<GoogleResponse> {

--- a/src/google.rs
+++ b/src/google.rs
@@ -78,14 +78,14 @@ pub struct GooglePlayDataJson {
 /// Retrieves the response body from google
 pub async fn google_response(
     service_account_key: Option<&ServiceAccountKey>,
-    uri: &str,
+    uri: String,
 ) -> Result<GoogleResponse> {
     let https = HttpsConnector::new();
     let client = Client::builder().build::<_, hyper::Body>(https);
 
     slog::debug!(slog_scope::logger(), "validate google parameters";
     "service_account_key" => service_account_key.map(|key| &key.client_email).unwrap_or(&"key not set".to_string()),
-    "uri" => uri);
+    "uri" => uri.clone());
 
     let req = if let Some(key) = service_account_key {
         let authenticator = ServiceAccountAuthenticator::builder(key.clone())

--- a/src/google.rs
+++ b/src/google.rs
@@ -2,6 +2,7 @@ use super::{error, error::Result, PurchaseResponse};
 use chrono::Utc;
 use serde::{de::Error, Deserialize, Serialize};
 use hyper::{body, Body, Client, Request};
+use hyper_tls::HttpsConnector;
 use yup_oauth2::{ServiceAccountAuthenticator, ServiceAccountKey};
 
 #[derive(Default, Serialize, Deserialize)]
@@ -17,15 +18,46 @@ pub struct GoogleResponse {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct GooglePlayParameters {
+pub struct GooglePlayData {
     pub json: String,
     pub signature: String,
     #[serde(rename = "skuDetails")]
     pub sku_details: String,
 }
 
+impl GooglePlayData {
+    pub fn from(payload: &str) -> std::result::Result<Self, serde_json::Error> {
+        serde_json::from_str(&payload)
+    }
+
+    pub fn get_uri(&self) -> Result<String> {
+        let parameters: GooglePlayDataJson = serde_json::from_str(&self.json)?;
+    
+        slog::debug!(slog_scope::logger(), "google purchase/receipt params";
+            "package" => &parameters.package_name,
+            "productId" => &parameters.product_id,
+            "token" => &parameters.token
+        );
+    
+        Ok(format!(
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{}/purchases/subscriptions/{}/tokens/{}",
+            parameters.package_name, parameters.product_id, parameters.token
+        ))
+    }
+
+    pub fn get_sku_details(&self) -> std::result::Result<GoogleSkuDetails, serde_json::Error> {
+        serde_json::from_str(&self.sku_details)
+    }
+}
+
+#[derive(Deserialize)]
+pub struct GoogleSkuDetails {
+    #[serde(rename = "type")]
+    pub sku_type: String,
+}
+
 #[derive(Serialize, Deserialize)]
-pub struct GooglePlayParametersJson {
+pub struct GooglePlayDataJson {
     #[serde(rename = "packageName")]
     pub package_name: String,
     #[serde(rename = "productId")]
@@ -43,11 +75,14 @@ pub struct GooglePlayParametersJson {
     pub purchase_state: i64, //0 - unspecified, 1 - purchased, 2 - pending
 }
 
-pub async fn validate_google(
-    client: &Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>,
+/// Retrieves the response body from google
+pub async fn google_response(
     service_account_key: Option<&ServiceAccountKey>,
     uri: &str,
-) -> Result<PurchaseResponse> {
+) -> Result<GoogleResponse> {
+    let https = HttpsConnector::new();
+    let client = Client::builder().build::<_, hyper::Body>(https);
+
     slog::debug!(slog_scope::logger(), "validate google parameters";
     "service_account_key" => service_account_key.map(|key| &key.client_email).unwrap_or(&"key not set".to_string()),
     "uri" => uri);
@@ -75,16 +110,21 @@ pub async fn validate_google(
             .body(Body::empty())
     }?;
 
-    let resp = client.request(req).await?;
-    let buf = body::to_bytes(resp).await?;
+    let response = client.request(req).await?;
+    let buf = body::to_bytes(response).await?;
     let string = String::from_utf8(buf.to_vec())?.replace("\n", "");
     slog::debug!(slog_scope::logger(), "Google response: {}", &string);
-    let response: GoogleResponse = serde_json::from_slice(&buf).map_err(|err| {
+    serde_json::from_slice(&buf).map_err(|err| {
         error::Error::SerdeError(serde_json::Error::custom(format!(
             "Failed to deserialize google response. Was the service account key set? Error message: {}", err)
         ))
-    })?;
+    })
+}
 
+pub async fn validate_google_subscription(
+    response: GoogleResponse,
+) -> Result<PurchaseResponse> {
+    
     let expiry_time = response.expiry_time.parse::<i64>()?;
     let now = Utc::now().timestamp_millis();
     let valid = expiry_time > now;
@@ -98,20 +138,4 @@ pub async fn validate_google(
     );
 
     Ok(PurchaseResponse { valid })
-}
-
-pub fn uri_from_payload(payload: &str) -> Result<String> {
-    let parameters: GooglePlayParameters = serde_json::from_str(&payload)?;
-    let parameters: GooglePlayParametersJson = serde_json::from_str(&parameters.json)?;
-
-    slog::debug!(slog_scope::logger(), "google purchase/receipt params";
-        "package" => &parameters.package_name,
-        "productId" => &parameters.product_id,
-        "token" => &parameters.token
-    );
-
-    Ok(format!(
-        "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{}/purchases/subscriptions/{}/tokens/{}",
-        parameters.package_name, parameters.product_id, parameters.token
-    ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,12 @@ mod apple;
 mod google;
 
 use error::Result;
+use apple::AppleUrls;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use yup_oauth2::ServiceAccountKey;
 
-pub use apple::{AppleResponse, AppleUrls, apple_response, validate_apple_subscription};
+pub use apple::{AppleResponse, apple_response, validate_apple_subscription};
 pub use google::{GoogleResponse, google_response, validate_google_subscription};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,12 +131,12 @@ mod tests {
     use mockito::mock;
     use serial_test::serial;
 
-    fn new_for_test(test_url: &str) -> UnityPurchaseValidator {
+    fn new_for_test<'a>(prod_url: &'a str, sandbox_url: &'a str) -> UnityPurchaseValidator<'a> {
         UnityPurchaseValidator {
             secret: Some(String::from("secret")),
             apple_urls: AppleUrls {
-                production: test_url,
-                sandbox: format!("{}/sb", test_url),
+                production: prod_url,
+                sandbox: sandbox_url,
             },
             service_account_key: None,
         }
@@ -168,7 +168,8 @@ mod tests {
 
         let url = &mockito::server_url();
 
-        let validator = new_for_test(url);
+        let sandbox = format!("{}/sb", url);
+        let validator = new_for_test(url, &sandbox);
 
         assert!(
             validator
@@ -198,7 +199,8 @@ mod tests {
 
         let url = &mockito::server_url();
 
-        let validator = new_for_test(url);
+        let sandbox = format!("{}/sb", url);
+        let validator = new_for_test(url, &sandbox);
 
         assert!(
             !validator
@@ -243,7 +245,8 @@ mod tests {
 
         let url = &mockito::server_url();
 
-        let validator = new_for_test(url);
+        let sandbox = format!("{}/sb", url);
+        let validator = new_for_test(url, &sandbox);
 
         assert!(
             validator
@@ -264,7 +267,8 @@ mod tests {
 
         let url = &mockito::server_url();
 
-        let validator = new_for_test(url);
+        let sandbox = format!("{}/sb", url);
+        let validator = new_for_test(url, &sandbox);
 
         assert!(
             !validator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use yup_oauth2::ServiceAccountKey;
 
 pub use apple::{AppleResponse, AppleUrls, apple_response, apple_response_with_urls, validate_apple_subscription};
-pub use google::{GoogleResponse, google_response, validate_google_subscription};
+pub use google::{GoogleResponse, google_response, google_response_with_uri, validate_google_subscription};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Platform {
@@ -96,7 +96,7 @@ impl Validator for UnityPurchaseValidator<'_> {
                     .map(|data| 
                         (
                             data.get_uri()
-                                .map(|uri| google_response(self.service_account_key.as_ref(), uri)),
+                                .map(|uri| google_response_with_uri(self.service_account_key.as_ref(), uri)),
                             data.get_sku_details()
                                 .map(|sku_details| sku_details.sku_type)
                         )
@@ -293,7 +293,7 @@ mod tests {
 
         let url = &mockito::server_url();
 
-        assert!(!validate_google_subscription(google::google_response(None, url.clone()).await.unwrap()).await.unwrap().valid);
+        assert!(!validate_google_subscription(google::google_response_with_uri(None, url.clone()).await.unwrap()).await.unwrap().valid);
     }
 
     #[tokio::test]
@@ -312,6 +312,6 @@ mod tests {
 
         let url = &mockito::server_url();
 
-        assert!(validate_google_subscription(google::google_response(None, url.clone()).await.unwrap()).await.unwrap().valid);    
+        assert!(validate_google_subscription(google::google_response_with_uri(None, url.clone()).await.unwrap()).await.unwrap().valid);    
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,15 @@ mod apple;
 mod google;
 
 use error::Result;
-use apple::{validate_apple_subscription, AppleUrls};
 use async_trait::async_trait;
-use google::{validate_google_subscription};
 use serde::{Deserialize, Serialize};
 use yup_oauth2::ServiceAccountKey;
 
 const APPLE_PROD_VERIFY_RECEIPT: &str = "https://buy.itunes.apple.com";
 const APPLE_TEST_VERIFY_RECEIPT: &str = "https://sandbox.itunes.apple.com";
 
-pub use apple::{AppleResponse, apple_response};
-pub use google::{GoogleResponse, google_response};
+pub use apple::{AppleResponse, AppleUrls, apple_response, validate_apple_subscription};
+pub use google::{GoogleResponse, google_response, validate_google_subscription};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Platform {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,11 @@ mod apple;
 mod google;
 
 use error::Result;
-use apple::AppleUrls;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use yup_oauth2::ServiceAccountKey;
 
-pub use apple::{AppleResponse, apple_response, validate_apple_subscription};
+pub use apple::{AppleResponse, AppleUrls, apple_response, apple_response_with_urls, validate_apple_subscription};
 pub use google::{GoogleResponse, google_response, validate_google_subscription};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -79,7 +78,7 @@ impl Validator for UnityPurchaseValidator<'_> {
 
         match receipt.store {
             Platform::AppleAppStore => {
-                let response = apple::apple_response_internal(receipt, &self.apple_urls, self.secret.as_ref()).await?;
+                let response = apple::apple_response_with_urls(receipt, &self.apple_urls, self.secret.as_ref()).await?;
                 if response.status == 0 {
                     //apple returns latest_receipt_info if it is a renewable subscription
                     match response.latest_receipt {


### PR DESCRIPTION
1. Added exposed functions for granular response handling on the client side (so instead of creating a validator and calling validate, users could call apple_response(), debug with the response, then call validate_apple_subscription(), for instance).
2. Created more in-depth validation in preparation for being able to handle other purchase types from validate()
3. More complete error handling on the google side so we actually get a PurchaseResponse with invalid input.

I figure this way, we get the best of both worlds. A convenience struct and function for those who just want to know "is this a valid purchase", and specific functions for people who want more in-depth error handling.